### PR TITLE
Fix idempotency for version lock broken in CentOS8

### DIFF
--- a/tasks/elasticsearch-RedHat-version-lock.yml
+++ b/tasks/elasticsearch-RedHat-version-lock.yml
@@ -8,7 +8,7 @@
 
 - name: RedHat - check if requested elasticsearch version lock exists
   become: yes
-  shell: yum versionlock list | grep -c {{es_package_name}}-{{es_version}}
+  shell: 'yum versionlock list | grep -c {{es_package_name}} | grep -c "{{es_version}}"'
   register: es_requested_version_locked
   args:
     warn: false


### PR DESCRIPTION
Fixes https://github.com/elastic/ansible-elasticsearch/issues/746